### PR TITLE
Sync package version to match NPM (1.0.4)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-wrapper",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "description": "OpenAI-compatible HTTP API wrapper for Claude Code CLI with Session Management",
   "main": "dist/cli.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Sync local package.json version to match the published NPM version (1.0.4)
- This fixes the version mismatch caused by improper release workflow

## Changes
- Update app/package.json version from 1.0.0 to 1.0.4

## Context
The previous release workflow published v1.0.4 to NPM but left local files at older versions. This PR aligns the repository state with the published package.

## Test plan
- [x] Version number updated correctly
- [x] No breaking changes to functionality
- [x] Ready for proper release workflow going forward

🤖 Generated with [Claude Code](https://claude.ai/code)