### PR TITLE
Hotfix v1.1.7

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-wrapper",
-  "version": "1.1.4",
+  "version": "1.1.7",
   "description": "OpenAI-compatible HTTP API wrapper for Claude Code CLI with Session Management",
   "main": "dist/cli.js",
   "bin": {
@@ -22,6 +22,7 @@
   },
   "scripts": {
     "build": "tsc > build.log 2>&1",
+    "prepublishOnly": "npm run build",
     "start": "node dist/cli.js",
     "dev": "ts-node src/cli.ts",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-wrapper",
-  "version": "1.1.4",
+  "version": "1.1.7",
   "description": "Production-ready OpenAI-compatible API wrapper for Claude Code CLI with streaming, sessions, and authentication",
   "main": "app/dist/cli.js",
   "bin": {


### PR DESCRIPTION
## Critical Fix: CLI Binary Execution

**Issue**: Published package v1.1.6 has broken CLI binaries (permission denied errors)

**Root Cause**: Removed postinstall script but didn't ensure dist/ files were pre-built before publishing

**Fix**: 
- Added `prepublishOnly` script to build dist/ files before publishing
- Ensures CLI binaries work after npm install

**Testing**:
- [x] CLI works after clean build
- [x] Package includes compiled JavaScript files
- [x] Binaries execute without permission errors